### PR TITLE
Use class instead of id for styling

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,7 +31,7 @@ module.exports = {
     blocks: {
         'localizedfooter': {
             process: function(block) {
-                return '<div id="page-footer"><hr>' + block.body + '</div>';
+                return '<div class="page-footer"><hr>' + block.body + '</div>';
             }
         }
     }


### PR DESCRIPTION
For pure styling, use .page-footer instead of use #page-footer, as the latter has special behavior (anchor and JS)